### PR TITLE
feat: 消息缓存与合并

### DIFF
--- a/_conf_schema.json
+++ b/_conf_schema.json
@@ -23,6 +23,12 @@
         "type": "float",
         "default": 60
     },
+    "wake_extend": {
+        "description": "唤醒延长（秒）",
+        "hint": "bot被唤醒后的多长时间内，持续保持唤醒状态(每个用户单独计时)。 设为0时关闭检测",
+        "type": "float",
+        "default": 3.0
+    },
     "empty_mention_pt": {
         "description": "空@消息提示模版",
         "hint": "使用此配置时请关闭Astrbot消息平台配置里的 “只@机器人是否触发等待” 和 “只@机器人触发等待时是否需要回复提醒”。 另外{username}会自动解析成用户昵称。 不填表示不启用空@回复",
@@ -35,12 +41,6 @@
         "type": "list",
         "default": []
     },
-    "wake_extend": {
-        "description": "唤醒延长时间（秒）",
-        "hint": "bot被唤醒后的多长时间内，持续保持唤醒状态(每个用户单独计时)。 设为0时关闭检测",
-        "type": "float",
-        "default": 3.0
-    },
     "relevant_wake": {
         "description": "相关性唤醒阈值",
         "hint": "当前消息与上文bot的消息相关性大时，唤醒bot。 降低阈值可更容易唤醒，保持对话连续性。 设为0时关闭检测",
@@ -51,7 +51,7 @@
         "description": "答疑唤醒阈值",
         "hint": "当群里有人问专业性问题时，唤醒bot。建议阈值高一点，日常聊天疑问句出现的频率非常高。 设为0时关闭检测",
         "type": "float",
-        "default": 0.9
+        "default": 0.88
     },
     "bored_wake": {
         "description": "无聊唤醒阈值",
@@ -79,9 +79,9 @@
     },
     "prob_wake": {
         "description": "兜底唤醒概率",
-        "hint": "上述所有唤醒机制都没能唤醒bot时，最后会按照此概率尝试唤醒bot，概率越大越容易唤醒，建议设置得非常小",
+        "hint": "上述所有唤醒机制都没能唤醒bot时，最后会按照此概率尝试唤醒bot(相当于Astrbot框架中的主动唤醒概率)，概率越大越容易唤醒，建议设置得非常小",
         "type": "float",
-        "default": 0.001
+        "default": 0.0005
     },
     "wake_forbidden_words":{
         "description": "唤醒词屏蔽词",

--- a/_conf_schema.json
+++ b/_conf_schema.json
@@ -11,11 +11,17 @@
         "type": "list",
         "default": []
     },
-    "member_wake_cd":{
-        "description": "唤醒CD",
-        "hint": "唤醒bot的CD(冷却时间)，每个成员单独计CD, 私聊不计CD, 单位秒",
-        "type": "int",
-        "default": 3
+    "wake_cd":{
+        "description": "唤醒CD(秒)",
+        "hint": "唤醒bot的CD(冷却时间)，每个成员单独计CD，bot处于唤醒CD时拒收该成员的一切消息，此CD优先级比其他CD高，建议别设太大，会影响挂起和唤醒延长的效果",
+        "type": "float",
+        "default": 0.5
+    },
+    "pend_cd": {
+        "description": "挂起CD(秒)",
+        "hint": "唤醒bot后, bot将挂起一段时间, 这段时间内如果还没等bot回复, 用户又向bot发起对话，则合并前后两次消息再请求LLM, 每个成员单独计CD, 单位秒",
+        "type": "float",
+        "default": 60
     },
     "empty_mention_pt": {
         "description": "空@消息提示模版",
@@ -32,8 +38,8 @@
     "wake_extend": {
         "description": "唤醒延长时间（秒）",
         "hint": "bot被唤醒后的多长时间内，持续保持唤醒状态(每个用户单独计时)。 设为0时关闭检测",
-        "type": "int",
-        "default": 3
+        "type": "float",
+        "default": 3.0
     },
     "relevant_wake": {
         "description": "相关性唤醒阈值",

--- a/main.py
+++ b/main.py
@@ -14,15 +14,18 @@ from .similarity import Similarity
 
 class MemberState(pydantic.BaseModel):
     uid: str
-    silence_until: int = 0  # 沉默到何时
+    silence_until: float = 0.0  # 沉默到何时
     msg_times: list[float] = []  # 最近消息时间列表
-    last_wake: int = 0  # 最后唤醒bot的时间
+    last_wake: float = 0.0  # 最后唤醒bot的时间
+    pend_cd: float = 0.0  # 挂起CD
+    pend: list[AstrMessageEvent] = []  # 事件缓存
+    model_config = pydantic.ConfigDict(arbitrary_types_allowed=True)
 
 
 class GroupState(pydantic.BaseModel):
     gid: str
     members: dict[str, MemberState] = {}  # uin -> state
-    shutup_until: int = 0  # 闭嘴到何时
+    shutup_until: float = 0.0  # 闭嘴到何时
 
 
 class StateManager:
@@ -37,15 +40,15 @@ class StateManager:
         return cls._groups[gid]
 
     @staticmethod
-    def now() -> int:
-        return int(time.time())
+    def now() -> float:
+        return time.time()
 
 
 @register(
     "astrbot_plugin_wakepro",
     "Zhalslar",
     "更强大的唤醒增强插件：提及唤醒、唤醒延长、唤醒CD、话题相关性唤醒、答疑唤醒、无聊唤醒、闭嘴机制、被骂沉默机制、唤醒屏蔽词",
-    "v1.0.4",
+    "v1.0.5",
 )
 class WakeProPlugin(Star):
     def __init__(self, context: Context, config: AstrBotConfig):
@@ -125,7 +128,7 @@ class WakeProPlugin(Star):
         bid: str = event.get_self_id()
         gid: str = event.get_group_id()
         uid: str = event.get_sender_id()
-        msg: str = event.message_str.strip()
+        msg: str = event.message_str
         g: GroupState = StateManager.get_group(gid)
 
         # 群聊白名单 / 用户黑名单
@@ -146,10 +149,7 @@ class WakeProPlugin(Star):
             g.members[uid] = MemberState(uid=uid)
 
         # 唤醒CD检查
-        if (
-            not event.is_private_chat()
-            and StateManager.now() - g.members[uid].last_wake < self.conf["member_wake_cd"]
-        ):
+        if StateManager.now() - g.members[uid].last_wake < self.conf["wake_cd"]:
             logger.debug(f"{uid} 处于唤醒CD中, 忽略此次唤醒")
             event.stop_event()
             return
@@ -169,6 +169,15 @@ class WakeProPlugin(Star):
             event.stop_event()
             return
 
+        # 消息缓存与合并
+        if StateManager.now() - g.members[uid].last_wake < self.conf["pend_cd"]:
+            pend = g.members[uid].pend
+            pend.append(event)
+            if len(pend) > 1:
+                for et in pend[:-1]:
+                    event.message_str = f"{et.message_str} {event.message_str}"
+                    et.stop_event()
+
         # 空@回复
         if (
             not msg
@@ -184,67 +193,72 @@ class WakeProPlugin(Star):
                 return
 
         # 各类唤醒条件
-        should_wake = event.is_at_or_wake_command
-        reason = None
+        wake = event.is_at_or_wake_command
+        reason = "at_or_cmd"
 
         # 提及唤醒
-        if not should_wake and self.conf["mention_wake"]:
+        if not wake and self.conf["mention_wake"]:
             names = [n for n in self.conf["mention_wake"] if n]
             for n in names:
                 if n and n in msg:
-                    should_wake = True
+                    wake = True
                     reason = f"提及唤醒({n})"
                     break
 
         # 唤醒延长（如果已经处于唤醒状态且在 wake_extend 秒内，每个用户单独延长唤醒时间）
         if (
-            not should_wake
+            not wake
             and self.conf["wake_extend"]
             and (StateManager.now() - g.members[uid].last_wake)
             <= int(self.conf["wake_extend"] or 0)
         ):
-            should_wake = True
+            wake = True
             reason = "唤醒延长"
 
-        # 5.3 话题相关性唤醒
-        if not should_wake and self.conf["relevant_wake"]:
+        # 话题相关性唤醒
+        if not wake and self.conf["relevant_wake"]:
             if bmsgs := await self._get_history_msg(event, count=5):
                 for bmsg in bmsgs:
                     simi = Similarity.cosine(msg, bmsg, gid)
                     if simi > self.conf["relevant_wake"]:
-                        should_wake = True
+                        wake = True
                         reason = f"话题相关性{simi}>{self.conf['relevant_wake']}"
                         break
 
         # 答疑唤醒
-        if not should_wake and self.conf["ask_wake"]:
+        if not wake and self.conf["ask_wake"]:
             if self.sent.ask(msg) > self.conf["ask_wake"]:
-                should_wake = True
+                wake = True
                 reason = "答疑唤醒"
 
         # 无聊唤醒
-        if not should_wake and self.conf["bored_wake"]:
+        if not wake and self.conf["bored_wake"]:
             if self.sent.bored(msg) > self.conf["bored_wake"]:
-                should_wake = True
+                wake = True
                 reason = "无聊唤醒"
 
         # 概率唤醒
-        if not should_wake and self.conf["prob_wake"]:
+        if not wake and self.conf["prob_wake"]:
             if random.random() < self.conf["prob_wake"]:
-                should_wake = True
+                wake = True
                 reason = "概率唤醒"
 
         # 触发唤醒
-        if should_wake:
-            event.is_at_or_wake_command = True
+        if wake:
+            # 挂起
+            g.members[uid].pend_cd = StateManager.now() + self.conf["pend_cd"]
+            # # 记录唤醒时间
             g.members[uid].last_wake = StateManager.now()
-            logger.info(f"[wakepro] 群({gid}){reason}：{msg}")
+            # 触发唤醒
+            event.is_at_or_wake_command = True
+            # 记录日志
+            logger.warning(f"[wakepro] 群({gid}){reason}：{msg}")
 
         # 闭嘴机制(对当前群聊闭嘴)
         if self.conf["shutup"]:
             shut_th = self.sent.shut(msg)
             if shut_th > self.conf["shutup"]:
-                shut_sec = int(shut_th * self.conf["sult_multiple"])
+                shut_sec = shut_th * self.conf["sult_multiple"]
                 g.shutup_until = StateManager.now() + shut_sec
                 reason = f"触发闭嘴机制{shut_sec}秒"
                 logger.info(f"[wakepro] 群({gid}){reason}：{msg}")
@@ -255,10 +269,25 @@ class WakeProPlugin(Star):
         if self.conf["insult"]:
             insult_th = self.sent.insult(msg)
             if insult_th > self.conf["insult"]:
-                silence_sec = int(insult_th * self.conf["sult_multiple"])
+                silence_sec = insult_th * self.conf["sult_multiple"]
                 g.members[uid].silence_until = StateManager.now() + silence_sec
                 reason = f"触发沉默机制{silence_sec}秒"
                 logger.info(f"[wakepro] 群({gid})用户({uid}){reason}：{msg}")
                 # event.stop_event() 本轮对话不沉默，方便回怼
                 return
+
+    @filter.on_decorating_result(priority=20)
+    async def on_message(self, event: AstrMessageEvent):
+        """发送消息前，清空请求消息的缓存"""
+        gid: str = event.get_group_id()
+        if (
+            gid
+            and self.conf["group_whitelist"]
+            and gid in self.conf["group_whitelist"]
+            and event.get_result()
+        ):
+            uid: str = event.get_sender_id()
+            g: GroupState = StateManager.get_group(gid)
+            g.members[uid].pend.clear()
+
 

--- a/main.py
+++ b/main.py
@@ -2,7 +2,7 @@ import asyncio
 import json
 import time
 import random
-import pydantic
+from pydantic import BaseModel, ConfigDict, Field
 from astrbot.api.event import filter
 from astrbot.api.star import Context, Star, register
 from astrbot.core.message.components import At
@@ -13,20 +13,20 @@ from .sentiment import Sentiment
 from .similarity import Similarity
 
 
-class MemberState(pydantic.BaseModel):
+class MemberState(BaseModel):
     uid: str
     silence_until: float = 0.0  # 沉默到何时
     msg_times: list[float] = []  # 最近消息时间列表
     last_wake: float = 0.0  # 最后唤醒bot的时间
     pend_cd: float = 0.0  # 挂起CD
     pend: list[AstrMessageEvent] = []  # 事件缓存
-    lock: asyncio.Lock = asyncio.Lock()  # 锁
-    model_config = pydantic.ConfigDict(arbitrary_types_allowed=True)
+    lock: asyncio.Lock = Field(default_factory=asyncio.Lock)
+    model_config = ConfigDict(arbitrary_types_allowed=True)
 
 
-class GroupState(pydantic.BaseModel):
+class GroupState(BaseModel):
     gid: str
-    members: dict[str, MemberState] = {}  # uin -> state
+    members: dict[str, MemberState] = Field(default_factory=dict)
     shutup_until: float = 0.0  # 闭嘴到何时
 
 

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -1,6 +1,6 @@
 name: astrbot_plugin_wakepro # 这是你的插件的唯一识别名。
 desc: 更强大的唤醒增强插件：提及唤醒、唤醒延长、空@唤醒、话题相关性唤醒、答疑唤醒、无聊唤醒、闭嘴机制、被骂沉默机制 # 插件简短描述
 help: 略  # 插件的帮助信息
-version: v1.0.4 # 插件版本号。格式：v1.1.1 或者 v1.1
+version: v1.0.5 # 插件版本号。格式：v1.1.1 或者 v1.1
 author: Zhalslar # 作者
 repo: https://github.com/Zhalslar/astrbot_plugin_wakepro # 插件的仓库地址


### PR DESCRIPTION
## Sourcery 总结

添加了消息缓存和在冷却期内合并消息的功能，通过使用浮点时间戳提高了时间精度，简化了唤醒逻辑，并将插件版本提升至 v1.0.5

新功能：
- 在可配置的 `pend_cd` 周期内缓存并合并连续的用户消息，使其成为一个单独的唤醒触发器
- 当机器人发送响应时，自动清除用户的待处理消息缓冲区

改进：
- 将各种冷却和计时字段 (`silence_until`, `last_wake`, `shutup_until`) 从整数类型切换为浮点类型，以获得更高的时间分辨率
- 通过统一唤醒标志并调整唤醒事件的日志级别，重构唤醒检测逻辑

杂项：
- 将插件版本提升至 v1.0.5

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

在 `pend_cd` 冷却期间实现消息缓冲和合并，将计时字段切换为浮点数以提高精度，重构唤醒检测逻辑，并将插件版本提升至 v1.0.5

新功能：
- 在可配置的 `pend_cd` 期间内，缓存并合并连续的用户消息，使其成为单个唤醒触发器
- 当机器人发送回复时，自动清除用户的待处理消息缓冲区

改进：
- 对 `silence_until`、`last_wake` 和 `shutup_until` 字段使用浮点时间戳，以提高时间精度
- 通过统一唤醒标志和整合日志记录来重构唤醒检测

构建：
- 将插件版本提升至 v1.0.5

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Implement message buffering and merging during the pend_cd cooldown, switch timing fields to float for improved precision, refactor wake detection logic, and bump the plugin version to v1.0.5

New Features:
- Cache and merge consecutive user messages within the configurable pend_cd period into a single wake trigger
- Automatically clear a user’s pending message buffer when the bot sends a response

Enhancements:
- Use float timestamps for silence_until, last_wake, and shutup_until fields for higher time precision
- Refactor wake detection by unifying the wake flag and consolidating logging

Build:
- Bump plugin version to v1.0.5

</details>

</details>