### PR TITLE
feat: 限制群聊缓存人数

### DIFF
--- a/_conf_schema.json
+++ b/_conf_schema.json
@@ -197,5 +197,16 @@
             "step": 10
         },
         "default": 500
+    },
+    "max_members_cache": {
+        "description": "群聊中最大缓存人数",
+        "hint": "每个群最多缓存多少人的聊天记录，超过此人数时，最久未活跃的人将被清除",
+        "type": "int",
+        "slider": {
+            "min": 1,
+            "max": 50,
+            "step": 1
+        },
+        "default": 16
     }
 }

--- a/main.py
+++ b/main.py
@@ -139,8 +139,20 @@ class WakeProPlugin(Star):
             event.stop_event()
             return
 
-        # 更新成员状态
+        # 更新成员状态（限制成员缓存数量）
         if uid not in g.members:
+            if len(g.members) >= self.conf["max_members_cache"]:
+                oldest_uid = min(
+                    g.members.items(),
+                    key=lambda item: max(
+                        item[1].last_wake,
+                        item[1].last_reply,
+                        item[1].silence_until,
+                    ),
+                )[0]
+                g.members.pop(oldest_uid, None)
+                logger.debug(f"[wakepro] 群({gid})裁剪成员缓存：{oldest_uid}")
+
             g.members[uid] = MemberState(uid=uid)
 
         member = g.members[uid]


### PR DESCRIPTION
## Summary by Sourcery

增强功能：
- 为每个群组的成员缓存添加可配置的最大大小限制，并在达到限制时移除最近最少活跃的成员。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhancements:
- Add a configurable maximum size for per-group member caches and prune the least recently active member when the limit is reached.

</details>