### PR TITLE
feat: 屏蔽QQ机器人

### DIFF
--- a/_conf_schema.json
+++ b/_conf_schema.json
@@ -6,7 +6,7 @@
         "items": {
             "lock_order": {
                 "description": "锁定顺序",
-                "hint": "锁定后将按内置顺序执行：名单检查 → 多级阻塞 → 指令屏蔽 → 智能唤醒 → 沉默检测",
+                "hint": "锁定后将按内置顺序执行：名单过滤 → 多级阻塞 → 指令屏蔽 → 智能唤醒 → 沉默检测",
                 "type": "bool",
                 "default": true
             },
@@ -15,14 +15,14 @@
                 "hint": "勾选表示启用该步骤；未锁定顺序时，将按当前列表顺序执行",
                 "type": "list",
                 "options": [
-                    "list(名单检查)",
+                    "list(名单过滤)",
                     "block(阻塞判断)",
                     "cmd(指令屏蔽)",
                     "wake(智能唤醒)",
                     "silence(沉默检测)"
                 ],
                 "default": [
-                    "list(名单检查)",
+                    "list(名单过滤)",
                     "block(阻塞判断)",
                     "cmd(指令屏蔽)",
                     "wake(智能唤醒)",
@@ -49,25 +49,43 @@
         }
     },
     "list": {
-        "description": "【名单检查】",
-        "hint": "",
+        "description": "【名单过滤】",
+        "hint": "注意检查顺序：屏蔽自身 -> 屏蔽机器人 -> 用户白名单 -> 群聊白名单 -> 用户黑名单 -> 群聊黑名单",
         "type": "object",
         "items": {
-            "white_groups": {
-                "description": "群聊白名单",
-                "hint": "仅在群聊白名单里的群启用本插件功能，不填表示所有群聊都启用",
+            "block_self": {
+                "description": "屏蔽Bot自身的消息",
+                "hint": "当 消息发送者ID 等于 Bot自身ID 时，消息将被屏蔽",
+                "type": "bool",
+                "default": false
+            },
+            "block_qqbot": {
+                "description": "屏蔽QQ机器人的消息",
+                "hint": "当 消息发送者ID 落在 QQ机器人ID范围 时，消息将被屏蔽。（仅QQ平台生效）",
+                "type": "bool",
+                "default": true
+            },
+            "white_users": {
+                "description": "用户白名单",
+                "hint": "填写后仅白名单里的用户能唤醒bot，不填则不检查",
                 "type": "list",
                 "default": []
             },
-            "black_groups": {
-                "description": "群聊黑名单",
-                "hint": "屏蔽黑名单中的群聊，该群消息无法唤醒bot",
+            "white_groups": {
+                "description": "群聊白名单",
+                "hint": "填写后仅白名单里的群聊能唤醒bot，不填则不检查",
                 "type": "list",
                 "default": []
             },
             "black_users": {
                 "description": "用户黑名单",
                 "hint": "屏蔽黑名单里的用户，使其全局无法唤醒bot",
+                "type": "list",
+                "default": []
+            },
+            "black_groups": {
+                "description": "群聊黑名单",
+                "hint": "屏蔽黑名单中的群聊，该群消息无法唤醒bot",
                 "type": "list",
                 "default": []
             }
@@ -384,7 +402,7 @@
         "type": "object",
         "items": {
             "builtin_cmds": {
-                "description": "要屏蔽的内置指令",
+                "description": "内置指令",
                 "hint": "定义哪些指令属于内置指令",
                 "type": "list",
                 "default": [
@@ -414,7 +432,7 @@
             },
             "block_builtin": {
                 "description": "禁止使用内置指令",
-                "hint": "内置指令即指Astrbot自带的命令，如help, tts, llm等，内置指令被屏蔽后不再会唤醒bot, 从而让你的bot更像真人",
+                "hint": "开启后，内置指令将无法唤醒bot,",
                 "type": "bool",
                 "default": false
             },

--- a/core/model.py
+++ b/core/model.py
@@ -64,10 +64,13 @@ class BlockReason(str, Enum):
     """
     阻塞原因
     """
-    SELF="self"
+
+    SELF = "self"
+    QQBOT = "qqbot"
+    WHITE_USER = "white_user"
     WHITE_GROUP = "white_group"
-    BLACK_GROUP = "black_group"
     BLACK_USER = "black_user"
+    BLACK_GROUP = "black_group"
     WAKE_CD = "wake_cd"
     FORBIDDEN = "forbidden"
     BUILTIN = "builtin"
@@ -83,9 +86,11 @@ class BlockReason(str, Enum):
     def label(self) -> str:
         return {
             BlockReason.SELF: "自唤醒",
-            BlockReason.WHITE_GROUP: "非白名单群",
-            BlockReason.BLACK_GROUP: "黑名单群",
+            BlockReason.QQBOT: "屏蔽QQ机器人",
+            BlockReason.WHITE_USER: "非白名单用户",
+            BlockReason.WHITE_GROUP: "非白名单群聊",
             BlockReason.BLACK_USER: "黑名单用户",
+            BlockReason.BLACK_GROUP: "黑名单群聊",
             BlockReason.WAKE_CD: "唤醒冷却中",
             BlockReason.FORBIDDEN: "包含违禁词",
             BlockReason.BUILTIN: "内置指令拦截",

--- a/core/utils.py
+++ b/core/utils.py
@@ -3,6 +3,33 @@ from astrbot.core.star.filter.command import CommandFilter
 from astrbot.core.star.filter.command_group import CommandGroupFilter
 from astrbot.core.star.star_handler import star_handlers_registry
 
+# 机器人账号区间（闭区间）
+BOT_RANGES: list[tuple[int, int]] = [
+    (3328144510, 3328144510),
+    (2854196301, 2854216399),
+    (66600000, 66600000),
+    (3889000000, 3889999999),
+    (4010000000, 4019999999),
+]
+
+
+def is_qqbot(uid: int | str) -> bool:
+    """
+    判断是否为 qqbot 账号
+
+    :param uid: 用户 ID（支持 str / int）
+    :return: 是否为 bot
+    """
+    try:
+        uid = int(uid)
+    except (TypeError, ValueError):
+        return False
+
+    for start, end in BOT_RANGES:
+        if start <= uid <= end:
+            return True
+    return False
+
 
 def get_all_commands() -> list[str]:
     """遍历所有注册的处理器获取所有命令"""

--- a/main.py
+++ b/main.py
@@ -165,7 +165,7 @@ class WakePlugin(Star):
         ):
             return StepResult(PhaseStatus.BLOCK, BlockReason.QQBOT)
         # 过滤用户白名单
-        if len(lconf["white_users"]) > 0 and ctx.gid not in lconf["white_users"]:
+        if len(lconf["white_users"]) > 0 and ctx.uid not in lconf["white_users"]:
             return StepResult(PhaseStatus.BLOCK, BlockReason.WHITE_USER)
         # 过滤群聊白名单
         if len(lconf["white_groups"]) > 0 and ctx.gid not in lconf["white_groups"]:


### PR DESCRIPTION
## Summary by Sourcery

添加 QQ 机器人账号检测，并将其集成到唤醒流水线的基于列表的过滤中，扩展封禁原因和标签，同时调整白名单/黑名单检查。

新特性：
- 引入 QQ 机器人账号范围定义以及用于识别 QQ 机器人用户 ID 的 `is_qqbot` 辅助函数。
- 在基于列表的唤醒上下文过滤器中，新增可配置的 QQ 机器人发送者拦截功能。
- 在现有群组白名单和黑名单逻辑的基础上，新增用户白名单过滤。

改进：
- 扩展 `BlockReason` 枚举及其标签，以涵盖 QQ 机器人拦截和用户白名单违规，并对现有白名单/黑名单相关标签进行澄清。
- 整理主消息处理流水线中的轻微格式问题和指令查找代码。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add QQ bot account detection and integrate it into the wake pipeline’s list-based filtering, expanding block reasons and labels while adjusting whitelist/blacklist checks.

New Features:
- Introduce QQ bot account range definitions and an is_qqbot helper for identifying QQ bot user IDs.
- Add configurable blocking of QQ bot senders within the list-based wake context filter.
- Add user whitelist filtering in addition to existing group whitelist and blacklist logic.

Enhancements:
- Extend BlockReason enum and labels to cover QQ bot blocking and user whitelist violations, and clarify existing whitelist/blacklist labels.
- Tidy minor formatting and command lookup code in the main message handling pipeline.

</details>