### PR TITLE
pref: 提供会话级配置

### DIFF
--- a/_conf_schema.json
+++ b/_conf_schema.json
@@ -1,93 +1,73 @@
 {
-    "pipeline": {
-        "description": "管道配置",
-        "type": "object",
-        "hint": "管道配置，用于配置组件的启停和运行顺序",
-        "items": {
-            "lock_order": {
-                "description": "锁定顺序",
-                "hint": "锁定后将按内置顺序执行：名单过滤 → 多级阻塞 → 指令屏蔽 → 智能唤醒 → 沉默检测",
-                "type": "bool",
-                "default": true
-            },
-            "steps": {
-                "description": "启用的步骤",
-                "hint": "勾选表示启用该步骤；未锁定顺序时，将按当前列表顺序执行",
-                "type": "list",
-                "options": [
-                    "gate(名单过滤)",
-                    "block(阻塞判断)",
-                    "cmd(指令屏蔽)",
-                    "wake(智能唤醒)",
-                    "silence(沉默检测)"
-                ],
-                "default": [
-                    "gate(名单过滤)",
-                    "block(阻塞判断)",
-                    "cmd(指令屏蔽)",
-                    "wake(智能唤醒)",
-                    "silence(沉默检测)"
-                ]
-            },
-            "admin_steps": {
-                "description": "对管理员无效的步骤",
-                "hint": "勾选后，该步骤对Bot管理员无效",
-                "type": "list",
-                "options": [
-                    "gate(名单检查)",
-                    "block(阻塞判断)",
-                    "cmd(指令屏蔽)",
-                    "wake(智能唤醒)",
-                    "silence(沉默检测)"
-                ],
-                "default": [
-                    "gate(名单检查)",
-                    "block(阻塞判断)",
-                    "cmd(指令屏蔽)"
-                ]
-            }
-        }
+    "global_blacklist": {
+        "description": "全局黑名单会话",
+        "hint": "全局黑名单会话将直接停止事件传播, 全局屏蔽",
+        "type": "list",
+        "default": []
     },
-    "gate": {
-        "description": "【名单过滤】",
-        "hint": "注意检查顺序：屏蔽自身 -> 屏蔽机器人 -> 用户白名单 -> 群聊白名单 -> 用户黑名单 -> 群聊黑名单",
+    "blacklist": {
+        "description": "黑名单会话",
+        "hint": "黑名单会话的消息将会跳过【智能唤醒】这一步, 支持直接填写会话ID、群聊ID、用户ID(如果冲突,请填写完整会话ID)",
+        "type": "list",
+        "default": []
+    },
+    "whitelist": {
+        "description": "白名单会话",
+        "hint": "白名单会话的消息将跳过这些步骤：【指令屏蔽】【阻塞判断】【沉默检测】。注意：本插件已自动将 Astrbot 设定的管理员加入此白名单。支持直接填写会话ID、群聊ID、用户ID(如果冲突,请填写完整会话ID)",
+        "type": "list",
+        "default": []
+    },
+    "command": {
+        "description": "【指令屏蔽】",
+        "hint": "注意：此步骤对白名单用户无效",
         "type": "object",
         "items": {
-            "block_self": {
-                "description": "屏蔽Bot自身的消息",
-                "hint": "当 消息发送者ID 等于 Bot自身ID 时，消息将被屏蔽。 注意可能导致无法接收好友申请、群邀请事件",
+            "builtin_cmds": {
+                "description": "内置指令",
+                "hint": "定义哪些指令属于内置指令",
+                "type": "list",
+                "default": [
+                    "llm",
+                    "t2i",
+                    "tts",
+                    "sid",
+                    "op",
+                    "wl",
+                    "dashboard_update",
+                    "alter_cmd",
+                    "provider",
+                    "model",
+                    "plugin",
+                    "plugin ls",
+                    "new",
+                    "switch",
+                    "rename",
+                    "del",
+                    "reset",
+                    "history",
+                    "persona",
+                    "tool ls",
+                    "key",
+                    "websearch"
+                ]
+            },
+            "block_builtin": {
+                "description": "禁止使用内置指令",
+                "hint": "开启后，内置指令将无法唤醒bot,",
                 "type": "bool",
                 "default": false
             },
-            "block_qqbot": {
-                "description": "屏蔽QQ机器人的消息",
-                "hint": "当 消息发送者ID 落在 QQ机器人ID范围 时，消息将被屏蔽。（仅QQ平台生效）",
+            "block_prefix_cmd": {
+                "description": "禁止使用前缀触发指令",
+                "hint": "开启后，即使用户使用前缀，也无法触发指令，但llm不受影响",
                 "type": "bool",
-                "default": true
+                "default": false
             },
-            "white_users": {
-                "description": "用户白名单",
-                "hint": "填写后仅白名单里的用户能唤醒bot，不填则不检查",
-                "type": "list",
-                "default": []
-            },
-            "white_groups": {
-                "description": "群聊白名单",
-                "hint": "填写后仅白名单里的群聊能唤醒bot，不填则不检查",
-                "type": "list",
-                "default": []
-            },
-            "black_users": {
-                "description": "用户黑名单",
-                "hint": "屏蔽黑名单里的用户，使其全局无法唤醒bot",
-                "type": "list",
-                "default": []
-            },
-            "black_groups": {
-                "description": "群聊黑名单",
-                "hint": "屏蔽黑名单中的群聊，该群消息无法唤醒bot",
-                "type": "list",
-                "default": []
+            "block_prefix_llm": {
+                "description": "禁止使用前缀唤醒LLM",
+                "hint": "开启后，即使用户使用前缀，也无法唤醒llm，但指令不受影响",
+                "type": "bool",
+                "default": false
             }
         }
     },
@@ -96,6 +76,29 @@
         "hint": "",
         "type": "object",
         "items": {
+            "wake_cd": {
+                "description": "唤醒冷却",
+                "hint": "bot回复的CD(冷却时间)，每个成员单独计CD，bot处于cd时不进行回复。 设为 0 表示关闭cd",
+                "type": "float",
+                "slider": {
+                    "min": 0,
+                    "max": 10,
+                    "step": 0.1
+                },
+                "default": 0.5
+            },
+            "block_qqbot": {
+                "description": "屏蔽QQ机器人",
+                "hint": "当 消息发送者ID 落在 QQ机器人ID范围 时, 屏蔽该用户消息。(仅QQ平台生效)",
+                "type": "bool",
+                "default": true
+            },
+            "reread": {
+                "description": "屏蔽复读",
+                "hint": "屏蔽其他人对Bot消息的复读， 从而避免Bot被重复的话唤醒",
+                "type": "bool",
+                "default": true
+            },
             "keywords": {
                 "description": "屏蔽词",
                 "hint": "当用户输入的消息包含这些词时，bot将不会被唤醒",
@@ -376,83 +379,12 @@
                     "阴毛",
                     "淫"
                 ]
-            },
-            "reread": {
-                "description": "屏蔽复读",
-                "hint": "屏蔽其他人对Bot消息的复读， 从而避免Bot被重复的话唤醒",
-                "type": "bool",
-                "default": true
-            },
-            "wake_cd": {
-                "description": "唤醒CD(秒)",
-                "hint": "唤醒bot的CD(冷却时间)，每个成员单独计CD，bot处于唤醒CD时拒收该成员的一切消息。 设为 0 表示关闭CD",
-                "type": "float",
-                "slider": {
-                    "min": 0,
-                    "max": 10,
-                    "step": 0.1
-                },
-                "default": 0.5
-            }
-        }
-    },
-    "cmd": {
-        "description": "【指令屏蔽】",
-        "hint": "",
-        "type": "object",
-        "items": {
-            "builtin_cmds": {
-                "description": "内置指令",
-                "hint": "定义哪些指令属于内置指令",
-                "type": "list",
-                "default": [
-                    "llm",
-                    "t2i",
-                    "tts",
-                    "sid",
-                    "op",
-                    "wl",
-                    "dashboard_update",
-                    "alter_cmd",
-                    "provider",
-                    "model",
-                    "plugin",
-                    "plugin ls",
-                    "new",
-                    "switch",
-                    "rename",
-                    "del",
-                    "reset",
-                    "history",
-                    "persona",
-                    "tool ls",
-                    "key",
-                    "websearch"
-                ]
-            },
-            "block_builtin": {
-                "description": "禁止使用内置指令",
-                "hint": "开启后，内置指令将无法唤醒bot,",
-                "type": "bool",
-                "default": false
-            },
-            "block_prefix_cmd": {
-                "description": "禁止使用前缀触发指令",
-                "hint": "开启后，即使用户使用前缀，也无法触发指令，但llm不受影响",
-                "type": "bool",
-                "default": false
-            },
-            "block_prefix_llm": {
-                "description": "禁止使用前缀唤醒LLM",
-                "hint": "开启后，即使用户使用前缀，也无法唤醒llm，但指令不受影响",
-                "type": "bool",
-                "default": false
             }
         }
     },
     "wake": {
         "description": "【智能唤醒】",
-        "hint": "",
+        "hint": "注意: 此步骤仅对触发LLM的消息生效",
         "type": "object",
         "items": {
             "names": {
@@ -467,10 +399,10 @@
                 "type": "float",
                 "slider": {
                     "min": 0,
-                    "max": 10,
+                    "max": 20,
                     "step": 1
                 },
-                "default": 5.0
+                "default": 8.0
             },
             "similar": {
                 "description": "相关性唤醒阈值",
@@ -481,7 +413,7 @@
                     "max": 1,
                     "step": 0.01
                 },
-                "default": 0.8
+                "default": 0.49
             },
             "ask": {
                 "description": "答疑唤醒阈值",
@@ -540,7 +472,7 @@
     },
     "silence": {
         "description": "【沉默检测】",
-        "hint": "注意：只有在唤醒后才会进行沉默检查，触发沉默后, 沉默期间无法唤醒bot",
+        "hint": "注意：此步骤对白名单用户无效",
         "type": "object",
         "items": {
             "shutup": {

--- a/core/config.py
+++ b/core/config.py
@@ -151,9 +151,9 @@ class PluginConfig(ConfigNode):
         self.context = context
         self.wake_prefix: list[str] = self.context.get_config().get("wake_prefix", [])
         self.admins_id: list[str] = context.get_config().get("admins_id", [])
-        self._nomalize_whitelist()
+        self._normalize_whitelist()
 
-    def _nomalize_whitelist(self):
+    def _normalize_whitelist(self):
         if not self.admins_id:
             return
         for admin_id in self.admins_id:

--- a/core/model.py
+++ b/core/model.py
@@ -95,6 +95,8 @@ class WakeContext:
     """命令"""
     is_admin: bool
     """是否为管理员事件"""
+    umo: str
+    """会话 ID"""
     gid: str
     """群组 ID"""
     uid: str
@@ -110,7 +112,6 @@ class WakeContext:
 
 
 class StepName(str, Enum):
-    GATE = "gate"
     BLOCK = "block"
     COMMAND = "command"
     SILENCE = "silence"

--- a/core/pipeline.py
+++ b/core/pipeline.py
@@ -4,7 +4,7 @@ from astrbot.api import logger
 
 from .config import PluginConfig
 from .model import WakeContext
-from .step import BaseStep, BlockStep, CommandStep, GateStep, SilenceStep, WakeStep
+from .step import BaseStep, BlockStep, CommandStep, SilenceStep, WakeStep
 
 
 class Pipeline:
@@ -16,80 +16,43 @@ class Pipeline:
     - 对外唯一接口：run
     """
 
-    # 默认顺序
-    STEP_REGISTRY: list[tuple[str, type[BaseStep]]] = [
-        ("gate", GateStep),
-        ("block", BlockStep),
-        ("wake", WakeStep),
-        ("command", CommandStep),
-        ("silence", SilenceStep),
+    STEP_REGISTRY: list[type[BaseStep]] = [
+        BlockStep,
+        WakeStep,
+        CommandStep,
+        SilenceStep,
     ]
 
     def __init__(self, config: PluginConfig):
         self.plugin_config = config
-        self.cfg = config.pipeline
         self._steps: list[BaseStep] = []
         self._build_steps()
 
     def _build_steps(self) -> None:
-        """
-        根据配置构建步骤实例（默认顺序或自定义顺序）
-        """
-        if self.cfg.lock_order:
-            for name, cls in self.STEP_REGISTRY:
-                if name in self.cfg._steps:
-                    step = cls(self.plugin_config)
-                    self._steps.append(step)
-        else:
-            step_map = dict(self.STEP_REGISTRY)
-            for name in self.cfg._steps:
-                cls = step_map.get(name)
-                if not cls:
-                    raise ValueError(f"Unknown pipeline step: {name}")
-                step = cls(self.plugin_config)
-                self._steps.append(step)
-
-    # =================== Lifecycle =======================
-
-    async def initialize(self) -> None:
-        """初始化所有步骤"""
-        for step in self._steps:
-            await step.initialize()
-
-    async def terminate(self) -> None:
-        """终止所有步骤"""
-        for step in self._steps:
-            await step.terminate()
+        for cls in self.STEP_REGISTRY:
+            step = cls(self.plugin_config)
+            self._steps.append(step)
 
     # ==================== run =====================
 
-    def _admin_skip(self, step_name: str, is_admin: bool) -> bool:
-        if not self.cfg._admin_steps:
-            return False
-        return is_admin and step_name in self.cfg._admin_steps
-
     async def run(self, ctx: WakeContext):
         for step in self._steps:
-            if self._admin_skip(step.name, ctx.is_admin):
-                continue
-
+            # 执行
             result = await step.handle(ctx)
-
+            # 标记唤醒
             if result.wake is True:
                 if ctx.member:
                     ctx.member.last_wake = ctx.now
                 ctx.event.is_at_or_wake_command = True
-
+            # 停止事件传播
             elif result.wake is False:
                 ctx.event.stop_event()
-
+            # 日志
             if result.msg:
                 logger.debug(result.msg)
-
+            # 记录延长唤醒
             if ctx.member:
                 ctx.member.can_prolong = result.prolong
-
+            # 中断流水线
             if result.abort:
                 break
-
-

--- a/core/step/__init__.py
+++ b/core/step/__init__.py
@@ -1,7 +1,6 @@
 from .base import BaseStep
 from .block import BlockStep
 from .command import CommandStep
-from .gate import GateStep
 from .silence import SilenceStep
 from .wake import WakeStep
 
@@ -9,7 +8,6 @@ __all__ = [
     "BaseStep",
     "BlockStep",
     "CommandStep",
-    "GateStep",
     "SilenceStep",
     "WakeStep",
 ]

--- a/core/step/base.py
+++ b/core/step/base.py
@@ -14,7 +14,13 @@ class BaseStep(ABC):
     name: StepName
 
     def __init__(self, config: PluginConfig):
-        self.plugin_config = config
+        self.config = config
+
+    def in_blacklist(self, ctx: WakeContext) -> bool:
+        return any(x in self.config.blacklist for x in (ctx.umo, ctx.uid, ctx.gid))
+
+    def in_whitelist(self, ctx: WakeContext) -> bool:
+        return any(x in self.config.whitelist for x in (ctx.umo, ctx.uid, ctx.gid))
 
     @abstractmethod
     async def handle(self, ctx: WakeContext) -> StepResult:

--- a/core/step/block.py
+++ b/core/step/block.py
@@ -46,7 +46,7 @@ class BlockStep(BaseStep):
     async def handle(self, ctx: WakeContext) -> StepResult:
         # 白名单检查
         if self.in_whitelist(ctx):
-            return StepResult(wake=False, abort=True, msg="白名单会话，跳过阻塞判断")
+            return StepResult(abort=True, msg="白名单会话，跳过阻塞判断")
         # 唤醒CD阻塞
         if (
             self.cfg.wake_cd > 0

--- a/core/step/block.py
+++ b/core/step/block.py
@@ -1,8 +1,21 @@
 import re
 
+from astrbot.core.platform.sources.aiocqhttp.aiocqhttp_message_event import (
+    AiocqhttpMessageEvent,
+)
+
 from ..config import PluginConfig
 from ..model import StepName, StepResult, WakeContext
 from .base import BaseStep
+
+# 机器人账号区间（闭区间）
+BOT_RANGES: list[tuple[int, int]] = [
+    (3328144510, 3328144510),
+    (2854196301, 2854216399),
+    (66600000, 66600000),
+    (3889000000, 3889999999),
+    (4010000000, 4019999999),
+]
 
 
 class BlockStep(BaseStep):
@@ -12,21 +25,28 @@ class BlockStep(BaseStep):
         super().__init__(config)
         self.cfg = config.block
 
+    @staticmethod
+    def _is_qqbot(uid: int | str) -> bool:
+        """
+        判断是否为 qqbot 账号
+
+        :param uid: 用户 ID（支持 str / int）
+        :return: 是否为 bot
+        """
+        try:
+            uid = int(uid)
+        except (TypeError, ValueError):
+            return False
+
+        for start, end in BOT_RANGES:
+            if start <= uid <= end:
+                return True
+        return False
+
     async def handle(self, ctx: WakeContext) -> StepResult:
-        # 违禁词阻塞
-        if self.cfg.keywords and ctx.plain:
-            for w in self.cfg.keywords:
-                if w in ctx.plain:
-                    return StepResult(wake=False, abort=True, msg=f"包含违禁词: {w}")
-        # 复读阻塞
-        if self.cfg.reread and ctx.plain and ctx.group:
-            cleaned = re.sub(r"[^\w\u4e00-\u9fff]", "", ctx.plain).lower()
-            for msg in ctx.group.bot_msgs:
-                if not msg:
-                    continue
-                m = re.sub(r"[^\w\u4e00-\u9fff]", "", msg).lower()
-                if cleaned == m:
-                    return StepResult(wake=False, abort=True, msg=f"已阻止复读: {msg}")
+        # 白名单检查
+        if self.in_whitelist(ctx):
+            return StepResult(wake=False, abort=True, msg="白名单会话，跳过阻塞判断")
         # 唤醒CD阻塞
         if (
             self.cfg.wake_cd > 0
@@ -38,5 +58,26 @@ class BlockStep(BaseStep):
                 abort=True,
                 msg=f"唤醒冷却中({self.cfg.wake_cd}秒)，已阻止唤醒",
             )
+        # 过滤QQ机器人
+        if (
+            self.cfg.block_qqbot
+            and isinstance(ctx.event, AiocqhttpMessageEvent)
+            and self._is_qqbot(ctx.uid)
+        ):
+            return StepResult(wake=False, abort=True, msg="过滤QQ机器人")
+        # 复读阻塞
+        if self.cfg.reread and ctx.plain and ctx.group:
+            cleaned = re.sub(r"[^\w\u4e00-\u9fff]", "", ctx.plain).lower()
+            for msg in ctx.group.bot_msgs:
+                if not msg:
+                    continue
+                m = re.sub(r"[^\w\u4e00-\u9fff]", "", msg).lower()
+                if cleaned == m:
+                    return StepResult(wake=False, abort=True, msg=f"已阻止复读: {msg}")
 
+        # 违禁词阻塞
+        if self.cfg.keywords and ctx.plain:
+            for w in self.cfg.keywords:
+                if w in ctx.plain:
+                    return StepResult(wake=False, abort=True, msg=f"包含违禁词: {w}")
         return StepResult()

--- a/core/step/command.py
+++ b/core/step/command.py
@@ -11,10 +11,14 @@ class CommandStep(BaseStep):
 
     def __init__(self, config: PluginConfig):
         super().__init__(config)
-        self.cfg = config.cmd
+        self.cfg = config.command
         self.wake_prefix = config.wake_prefix
 
     async def handle(self, ctx: WakeContext) -> StepResult:
+        # 白名单检查
+        if self.in_whitelist(ctx):
+            return StepResult(wake=False, abort=True, msg="白名单会话，跳过指令屏蔽")
+
         if self.cfg.block_builtin and ctx.cmd and ctx.cmd in self.cfg.builtin_cmds:
             return StepResult(wake=False, abort=True, msg=f"命令 '{ctx.cmd}' 已被禁用")
 

--- a/core/step/command.py
+++ b/core/step/command.py
@@ -17,7 +17,7 @@ class CommandStep(BaseStep):
     async def handle(self, ctx: WakeContext) -> StepResult:
         # 白名单检查
         if self.in_whitelist(ctx):
-            return StepResult(wake=False, abort=True, msg="白名单会话，跳过指令屏蔽")
+            return StepResult()
 
         if self.cfg.block_builtin and ctx.cmd and ctx.cmd in self.cfg.builtin_cmds:
             return StepResult(wake=False, abort=True, msg=f"命令 '{ctx.cmd}' 已被禁用")

--- a/core/step/silence.py
+++ b/core/step/silence.py
@@ -19,7 +19,7 @@ class SilenceStep(BaseStep):
 
         # 白名单检查
         if self.in_whitelist(ctx):
-            return StepResult(wake=False, abort=True, msg="白名单会话，跳过沉默检查")
+            return StepResult()
 
         # 闭嘴沉默
         if self.cfg.shutup < 1 and ctx.plain and ctx.group:

--- a/core/step/silence.py
+++ b/core/step/silence.py
@@ -17,6 +17,10 @@ class SilenceStep(BaseStep):
         if not ctx.event.is_at_or_wake_command:
             return StepResult()
 
+        # 白名单检查
+        if self.in_whitelist(ctx):
+            return StepResult(wake=False, abort=True, msg="白名单会话，跳过沉默检查")
+
         # 闭嘴沉默
         if self.cfg.shutup < 1 and ctx.plain and ctx.group:
             th = sentiment.shut(ctx.plain)

--- a/core/step/wake.py
+++ b/core/step/wake.py
@@ -16,6 +16,7 @@ class WakeStep(BaseStep):
     def __init__(self, config: PluginConfig):
         super().__init__(config)
         self.cfg = config.wake
+        self.blacklist = config.blacklist
         self.interest = Interest(self.cfg._interest_words)
         self.similarity = Similarity()
 
@@ -25,6 +26,13 @@ class WakeStep(BaseStep):
             return StepResult(wake=False, abort=True, msg="已沉默该群聊，禁止唤醒")
         if ctx.member and ctx.member.silence_until > ctx.now:
             return StepResult(wake=False, abort=True, msg="已沉默该用户，禁止唤醒")
+
+        # 跳过黑名单
+        if self.in_blacklist(ctx):
+            return StepResult(abort=True, msg="黑名单会话，跳过智能唤醒")
+        # 跳过指令消息
+        if ctx.cmd:
+            return StepResult(abort=True, msg="指令消息，跳过智能唤醒")
 
         for seg in ctx.chain:
             # 艾特唤醒

--- a/core/step/wake.py
+++ b/core/step/wake.py
@@ -29,10 +29,10 @@ class WakeStep(BaseStep):
 
         # 跳过黑名单
         if self.in_blacklist(ctx):
-            return StepResult(abort=True, msg="黑名单会话，跳过智能唤醒")
+            return StepResult(msg="黑名单会话，跳过智能唤醒")
         # 跳过指令消息
         if ctx.cmd:
-            return StepResult(abort=True, msg="指令消息，跳过智能唤醒")
+            return StepResult(msg="指令消息，跳过智能唤醒")
 
         for seg in ctx.chain:
             # 艾特唤醒


### PR DESCRIPTION
## Summary by Sourcery

引入新的类型化配置节点系统，支持会话级黑/白名单，并据此简化消息处理流水线。

新特性：
- 添加通用的 `ConfigNode` 抽象，用于提供带类型信息的、可嵌套的配置对象，并支持可选持久化。
- 基于统一的消息来源、用户 ID 和群组 ID，新增全局与会话级黑名单、白名单支持，包括自动将管理员加入白名单。
- 在拦截步骤中引入基于已知 ID 范围的 QQ 机器人账号过滤。

改进：
- 通过移除 gate 步骤并将步骤顺序固定为标准序列，简化处理流水线。
- 优化唤醒逻辑，对被拉黑的会话和指令类消息跳过智能唤醒。
- 通过根级 `save_config` 方法显式保存插件配置，并对底层配置数据提供只读视图。
- 精简发送回复后的状态更新逻辑，并增加对缺失成员状态的防护。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a new typed configuration node system with session-level black/white lists and simplify the message handling pipeline accordingly.

New Features:
- Add a generic ConfigNode abstraction to provide typed, nested configuration objects with optional persistence.
- Add global, per-session blacklist and whitelist support based on unified message origin, user ID, and group ID, including automatic admin whitelisting.
- Introduce QQ bot account filtering using known ID ranges in the blocking step.

Enhancements:
- Simplify the processing pipeline by removing the gate step and fixing step ordering to a standard sequence.
- Refine wake logic to skip intelligent wake-up for blacklisted sessions and command messages.
- Make plugin configuration saving explicit via a root save_config method and expose read-only views of underlying config data.
- Streamline state updates after sending replies and guard against missing member state.

</details>